### PR TITLE
Begin BSD (kqueue) implementation

### DIFF
--- a/depend.c
+++ b/depend.c
@@ -1,0 +1,48 @@
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+/* simple program that keeps running until a given process exits */
+
+int main(int argc, char *argv[]) {
+	int kq;
+	struct kevent events[1];
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s pid\n", argv[0]);
+		exit(1);
+	}
+
+	if ((kq = kqueue()) == -1) err(1, "kqueue");
+
+	struct kevent change = { // event to watch for
+		.ident = fd,
+		.filter = EVFILT_PROC,
+		.flags = EV_ADD | EV_CLEAR,
+		.fflags = NOTE_EXIT,
+		.data = 0,
+		.udata = NULL
+	};
+
+	if (pledge("stdio", NULL) == -1) err(1, "pledge");
+
+	for (;;) {
+		int n;
+		/* register changes and wait for events */
+		if ((n = kevent(kq, &change, file_count, events, file_count, NULL)) == -1)
+			err(1, "kevent wait");
+		if (n > 0) {
+			for (int i = 0; i < n; i++) {
+				if (events[i].flags & EV_ERROR)
+					errx(1, "event error: %s", strerror(events[i].data));
+				if (events[i].fflags & NOTE_EXIT)
+					exit(0);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is a simple proof-of-concept program (not tested) that takes a pid as argv[1] and keeps running until the process with that pid has exited. The program returns 0 when watched process exits, or 1 on event error.

The rest is just a matter of using getppid(2) instead of having the user specify the pid and forking the process specified by the user, killing it when a NOTE_EXIT is encountered.